### PR TITLE
feat: add ping endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "redis-clone"
+version = "0.1.0"
+authors = ["Arvid Berndtsson <arvid@berndtsson.me>"]
+edition = "2024"
+
+
+[dependencies]
+anyhow = "1.0.59"                                   # error handling
+bytes = "1.3.0"                                     # helps manage buffers
+thiserror = "1.0.32"                                # error handling
+tokio = { version = "1.23.0", features = ["full"] } # async networking

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,36 @@
+#![allow(unused_imports)]
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+};
+
+fn main() {
+    let listener = TcpListener::bind("127.0.0.1:6379").unwrap();
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(mut _stream) => {
+                println!("accepted new connection");
+
+                // A buffer to store the command, we do not need to relocate this every time, which is why we declare it outside the loop
+                let mut buffer = [0; 512];
+
+                loop {
+                    // Read the command from the stream into the buffer
+                    let read_count = _stream.read(&mut buffer).unwrap();
+
+                    // If the read count is 0, the client has disconnected, so break out of the loop
+                    if read_count == 0 {
+                        break;
+                    }
+
+                    // Respond to a PING command with PONG
+                    _stream.write(b"+PONG\r\n").unwrap();
+                }
+            }
+            Err(e) => {
+                println!("error: {}", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request sets up the initial structure for a Redis clone project in Rust. It includes the addition of the `Cargo.toml` file to manage dependencies and a basic implementation of a TCP server in `main.rs` that can respond to PING commands.

### Project setup:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R1-R12): Added package metadata and dependencies for error handling, buffer management, and async networking.

### Basic TCP server implementation:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR1-R36): Implemented a TCP server that listens on port 6379 and responds to PING commands with PONG.