### PR TITLE
build: fix incorrect rust edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "redis-clone"
 version = "0.1.0"
 authors = ["Arvid Berndtsson <arvid@berndtsson.me>"]
-edition = "2024"
+edition = "2021"
 
 
 [dependencies]


### PR DESCRIPTION
This pull request includes a small change to the `Cargo.toml` file. The change the Rust edition from 2024 to 2021.

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L5-R5): Changed the Rust edition from 2024 to 2021.