### PR TITLE
feat: add event loop support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,33 @@
 #![allow(unused_imports)]
-use std::{
-    io::{Read, Write},
-    net::TcpListener,
-};
+use tokio::net::TcpListener;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-fn main() {
-    let listener = TcpListener::bind("127.0.0.1:6379").unwrap();
+#[tokio::main]
+async fn main() {
+    
+    println!("Logs from your program will appear here!");
 
-    for stream in listener.incoming() {
+
+    let listener = TcpListener::bind("127.0.0.1:6379").await.unwrap();
+    
+    loop {
+        let stream = listener.accept().await;
+    
         match stream {
-            Ok(mut _stream) => {
+            Ok((mut _stream, _)) => {
                 println!("accepted new connection");
 
-                // A buffer to store the command, we do not need to relocate this every time, which is why we declare it outside the loop
-                let mut buffer = [0; 512];
-
-                loop {
-                    // Read the command from the stream into the buffer
-                    let read_count = _stream.read(&mut buffer).unwrap();
-
-                    // If the read count is 0, the client has disconnected, so break out of the loop
-                    if read_count == 0 {
-                        break;
+                tokio::spawn(async move {
+                    let mut buf = [0; 512];
+                    loop {
+                        let read_count = _stream.read(&mut buf).await.unwrap();
+                        if read_count == 0 {
+                            break;
+                        }
+        
+                        _stream.write(b"+PONG\r\n").await.unwrap();
                     }
-
-                    // Respond to a PING command with PONG
-                    _stream.write(b"+PONG\r\n").unwrap();
-                }
+                });
             }
             Err(e) => {
                 println!("error: {}", e);


### PR DESCRIPTION
This pull request refactors the `main` function in `src/main.rs` to use asynchronous I/O with the Tokio library. The most important changes include replacing the standard library's synchronous I/O with Tokio's asynchronous I/O, updating the `main` function to be asynchronous, and restructuring the connection handling loop to use Tokio's asynchronous tasks.

**Asynchronous I/O Refactor:**

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL2-R30): Replaced `std::net::TcpListener` with `tokio::net::TcpListener` and synchronous I/O operations with their asynchronous counterparts (`tokio::io::{AsyncReadExt, AsyncWriteExt}`).
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL2-R30): Updated the `main` function to be asynchronous by using the `#[tokio::main]` attribute.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL2-R30): Restructured the connection handling loop to use `tokio::spawn` for handling each connection in a separate asynchronous task.